### PR TITLE
Add switching service product and workflows

### DIFF
--- a/migrations/versions/schema/2026-06-22_e9c7f020ab00_add_switchingservice.py
+++ b/migrations/versions/schema/2026-06-22_e9c7f020ab00_add_switchingservice.py
@@ -1,0 +1,115 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add switchingservice product.
+
+Revision ID: e9c7f020ab00
+Revises: 13e35d8ae1ed
+Create Date: 2026-06-22 13:15:20.500588
+
+"""
+
+from uuid import uuid4
+
+from alembic import op
+from orchestrator.core.migrations.helpers import (
+    create,
+    create_workflow,
+    delete,
+    delete_workflow,
+    ensure_default_workflows,
+)
+from orchestrator.core.targets import Target
+
+# revision identifiers, used by Alembic.
+revision = "e9c7f020ab00"
+down_revision = "13e35d8ae1ed"
+branch_labels = None
+depends_on = None
+
+new_products = {
+    "products": {
+        "switchingservice": {
+            "product_id": uuid4(),
+            "product_type": "SwitchingService",
+            "description": "Network Service Interface switching service",
+            "tag": "SWITCHINGSERVICE",
+            "status": "active",
+            "root_product_block": "SwitchingService",
+            "fixed_inputs": {},
+        },
+    },
+    "product_blocks": {
+        "SwitchingService": {
+            "product_block_id": uuid4(),
+            "description": "Switching service product block",
+            "tag": "SWITCHINGSERVICE",
+            "status": "active",
+            "resources": {
+                "switching_service_id": "Unique NSI switching service identifier",
+                "switching_service_name": "Switching service name",
+            },
+            "depends_on_block_relations": [
+                "Topology",
+            ],
+        },
+    },
+    "workflows": {},
+}
+
+new_workflows = [
+    {
+        "name": "create_switchingservice",
+        "target": Target.CREATE,
+        "is_task": False,
+        "description": "Create switchingservice",
+        "product_type": "SwitchingService",
+    },
+    {
+        "name": "modify_switchingservice",
+        "target": Target.MODIFY,
+        "is_task": False,
+        "description": "Modify switchingservice",
+        "product_type": "SwitchingService",
+    },
+    {
+        "name": "terminate_switchingservice",
+        "target": Target.TERMINATE,
+        "is_task": False,
+        "description": "Terminate switchingservice",
+        "product_type": "SwitchingService",
+    },
+    {
+        "name": "validate_switchingservice",
+        "target": Target.VALIDATE,
+        "is_task": True,
+        "description": "Validate switchingservice",
+        "product_type": "SwitchingService",
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    create(conn, new_products)
+    for workflow in new_workflows:
+        create_workflow(conn, workflow)
+    ensure_default_workflows(conn)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for workflow in new_workflows:
+        delete_workflow(conn, workflow["name"])
+
+    delete(conn, new_products)

--- a/products/product_blocks/switchingservice.py
+++ b/products/product_blocks/switchingservice.py
@@ -23,17 +23,13 @@ from products.product_blocks.topology import (
 )
 
 
-class SwitchingServiceBlockInactive(
-    ProductBlockModel, product_block_name="SwitchingService"
-):
+class SwitchingServiceBlockInactive(ProductBlockModel, product_block_name="SwitchingService"):
     switching_service_id: str | None = None
     switching_service_name: str | None = None
     topology: TopologyBlockInactive | None = None
 
 
-class SwitchingServiceBlockProvisioning(
-    SwitchingServiceBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
-):
+class SwitchingServiceBlockProvisioning(SwitchingServiceBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
     switching_service_id: str
     switching_service_name: str
     topology: TopologyBlockProvisioning
@@ -44,9 +40,7 @@ class SwitchingServiceBlockProvisioning(
         return f"{self.name} {self.switching_service_id}"
 
 
-class SwitchingServiceBlock(
-    SwitchingServiceBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
-):
+class SwitchingServiceBlock(SwitchingServiceBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
     switching_service_id: str
     switching_service_name: str
     topology: TopologyBlock

--- a/products/product_blocks/switchingservice.py
+++ b/products/product_blocks/switchingservice.py
@@ -1,0 +1,52 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from orchestrator.core.domain.base import ProductBlockModel
+from orchestrator.core.types import SubscriptionLifecycle
+from pydantic import computed_field
+
+from products.product_blocks.topology import (
+    TopologyBlock,
+    TopologyBlockInactive,
+    TopologyBlockProvisioning,
+)
+
+
+class SwitchingServiceBlockInactive(
+    ProductBlockModel, product_block_name="SwitchingService"
+):
+    switching_service_id: str | None = None
+    switching_service_name: str | None = None
+    topology: TopologyBlockInactive | None = None
+
+
+class SwitchingServiceBlockProvisioning(
+    SwitchingServiceBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+):
+    switching_service_id: str
+    switching_service_name: str
+    topology: TopologyBlockProvisioning
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def title(self) -> str:
+        return f"{self.name} {self.switching_service_id}"
+
+
+class SwitchingServiceBlock(
+    SwitchingServiceBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
+):
+    switching_service_id: str
+    switching_service_name: str
+    topology: TopologyBlock

--- a/products/product_blocks/switchingservice.py
+++ b/products/product_blocks/switchingservice.py
@@ -37,7 +37,7 @@ class SwitchingServiceBlockProvisioning(SwitchingServiceBlockInactive, lifecycle
     @computed_field  # type: ignore[prop-decorator]
     @property
     def title(self) -> str:
-        return f"{self.name} {self.switching_service_id}"
+        return f"SW {self.switching_service_id.removeprefix('urn:ogf:network:')}"
 
 
 class SwitchingServiceBlock(SwitchingServiceBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):

--- a/products/product_blocks/topology.py
+++ b/products/product_blocks/topology.py
@@ -29,7 +29,7 @@ class TopologyBlockProvisioning(TopologyBlockInactive, lifecycle=[SubscriptionLi
     @computed_field  # type: ignore[prop-decorator]
     @property
     def title(self) -> str:
-        return f"{self.name} {self.topology_id}"
+        return f"{self.name} {self.topology_id.removeprefix('urn:ogf:network:')}"
 
 
 class TopologyBlock(TopologyBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):

--- a/products/product_blocks/topology.py
+++ b/products/product_blocks/topology.py
@@ -22,9 +22,7 @@ class TopologyBlockInactive(ProductBlockModel, product_block_name="Topology"):
     topology_name: str | None = None
 
 
-class TopologyBlockProvisioning(
-    TopologyBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
-):
+class TopologyBlockProvisioning(TopologyBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
     topology_id: str
     topology_name: str
 
@@ -34,8 +32,6 @@ class TopologyBlockProvisioning(
         return f"{self.name} {self.topology_id}"
 
 
-class TopologyBlock(
-    TopologyBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
-):
+class TopologyBlock(TopologyBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
     topology_id: str
     topology_name: str

--- a/products/product_types/switchingservice.py
+++ b/products/product_types/switchingservice.py
@@ -26,13 +26,9 @@ class SwitchingServiceInactive(SubscriptionModel, is_base=True):
     switchingservice: SwitchingServiceBlockInactive
 
 
-class SwitchingServiceProvisioning(
-    SwitchingServiceInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
-):
+class SwitchingServiceProvisioning(SwitchingServiceInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
     switchingservice: SwitchingServiceBlockProvisioning
 
 
-class SwitchingService(
-    SwitchingServiceProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
-):
+class SwitchingService(SwitchingServiceProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
     switchingservice: SwitchingServiceBlock

--- a/products/product_types/switchingservice.py
+++ b/products/product_types/switchingservice.py
@@ -1,0 +1,38 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from orchestrator.core.domain.base import SubscriptionModel
+from orchestrator.core.types import SubscriptionLifecycle
+
+from products.product_blocks.switchingservice import (
+    SwitchingServiceBlock,
+    SwitchingServiceBlockInactive,
+    SwitchingServiceBlockProvisioning,
+)
+
+
+class SwitchingServiceInactive(SubscriptionModel, is_base=True):
+    switchingservice: SwitchingServiceBlockInactive
+
+
+class SwitchingServiceProvisioning(
+    SwitchingServiceInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+):
+    switchingservice: SwitchingServiceBlockProvisioning
+
+
+class SwitchingService(
+    SwitchingServiceProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]
+):
+    switchingservice: SwitchingServiceBlock

--- a/products/product_types/topology.py
+++ b/products/product_types/topology.py
@@ -26,9 +26,7 @@ class TopologyInactive(SubscriptionModel, is_base=True):
     topology: TopologyBlockInactive
 
 
-class TopologyProvisioning(
-    TopologyInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
-):
+class TopologyProvisioning(TopologyInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]):
     topology: TopologyBlockProvisioning
 
 

--- a/products/services/description.py
+++ b/products/services/description.py
@@ -26,6 +26,7 @@ from orchestrator.core.domain.base import (
     SubscriptionModel,
 )
 
+from products.product_types.switchingservice import SwitchingServiceProvisioning
 from products.product_types.topology import TopologyProvisioning
 
 
@@ -38,3 +39,10 @@ def description(model: ProductModel | ProductBlockModel | SubscriptionModel) -> 
 @description.register
 def _topology_description(topology: TopologyProvisioning) -> str:
     return f"{topology.product.name} {topology.topology.topology_name}"
+
+
+@description.register
+def _switchingservice_description(
+    switchingservice: SwitchingServiceProvisioning,
+) -> str:
+    return f"{switchingservice.product.name} {switchingservice.switchingservice.switching_service_name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ testpaths = ["tests"]
 
 [tool.ruff]
 target-version = "py313"
+line-length = 120
 extend-exclude = ["migrations"]
 
 [tool.mypy]

--- a/services/dds_proxy.py
+++ b/services/dds_proxy.py
@@ -31,6 +31,7 @@ from typing import Any
 import httpx
 import structlog
 from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
 
 from settings import settings
 
@@ -57,6 +58,20 @@ class DdsTopology(BaseModel):
     name: str
 
 
+class DdsSwitchingService(BaseModel):
+    """A switching service from the dds-proxy ``GET /switching-services`` endpoint.
+
+    The proxy serialises with camelCase aliases (``topologyId``); only the needed fields are kept.
+    """
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, populate_by_name=True, extra="ignore"
+    )
+
+    id: str
+    topology_id: str
+
+
 def _client_kwargs() -> dict[str, Any]:
     """Build the httpx client arguments for the configured authentication mode."""
     if settings.dds_proxy_mtls_enabled:
@@ -76,8 +91,8 @@ def _client_kwargs() -> dict[str, Any]:
     }
 
 
-def fetch_topologies() -> list[DdsTopology]:
-    """Return all topologies known to the dds-proxy.
+def _fetch(path: str) -> list[dict[str, Any]]:
+    """GET ``path`` from the dds-proxy and return the decoded JSON list.
 
     Raises:
         DdsProxyError: when the proxy cannot be reached or returns an error response.
@@ -88,18 +103,29 @@ def fetch_topologies() -> list[DdsTopology]:
         **_client_kwargs(),
     ) as client:
         try:
-            response = client.get("/topologies")
+            response = client.get(path)
             response.raise_for_status()
         except httpx.HTTPError as exc:
             logger.warning(
-                "dds-proxy /topologies request failed",
+                "dds-proxy request failed",
+                path=path,
                 base_url=settings.dds_proxy_base_url,
                 error=str(exc),
             )
-            # Suppress the httpx/httpcore exception chain: the cause (e.g. "Connection refused")
-            # is already folded into the message, and the chain only adds noise to the logs.
+            # Suppress the httpx/httpcore chain: the cause is already folded into the message.
             raise DdsProxyError(
-                f"Could not fetch topologies from dds-proxy at {settings.dds_proxy_base_url}: {exc}"
+                f"Could not fetch {path} from dds-proxy at {settings.dds_proxy_base_url}: {exc}"
             ) from None
 
-        return [DdsTopology.model_validate(item) for item in response.json()]
+        data: list[dict[str, Any]] = response.json()
+        return data
+
+
+def fetch_topologies() -> list[DdsTopology]:
+    """Return all topologies known to the dds-proxy."""
+    return [DdsTopology.model_validate(item) for item in _fetch("/topologies")]
+
+
+def fetch_switching_services() -> list[DdsSwitchingService]:
+    """Return all switching services known to the dds-proxy."""
+    return [DdsSwitchingService.model_validate(item) for item in _fetch("/switching-services")]

--- a/services/dds_proxy.py
+++ b/services/dds_proxy.py
@@ -64,9 +64,7 @@ class DdsSwitchingService(BaseModel):
     The proxy serialises with camelCase aliases (``topologyId``); only the needed fields are kept.
     """
 
-    model_config = ConfigDict(
-        alias_generator=to_camel, populate_by_name=True, extra="ignore"
-    )
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="ignore")
 
     id: str
     topology_id: str

--- a/settings.py
+++ b/settings.py
@@ -29,9 +29,7 @@ class Settings(BaseSettings):
     dds_proxy_mtls_enabled: bool = False
     dds_proxy_client_cert: str | None = None  # path to the PEM client certificate
     dds_proxy_client_key: str | None = None  # path to the PEM private key
-    dds_proxy_ca_bundle: str | None = (
-        None  # path to a CA bundle used to verify the server
-    )
+    dds_proxy_ca_bundle: str | None = None  # path to a CA bundle used to verify the server
 
     # Local-development shortcut, used ONLY when mTLS is disabled. The dds-proxy trusts the
     # edge identity headers; these fake the mTLS auth path (X-Auth-Method is the proxy's

--- a/switchingservice.yaml
+++ b/switchingservice.yaml
@@ -1,0 +1,25 @@
+config:
+  summary_forms: true
+name: switchingservice
+type: SwitchingService
+tag: SWITCHINGSERVICE
+description: "Network Service Interface switching service"
+product_blocks:
+  - name: switchingservice
+    type: SwitchingService
+    tag: SWITCHINGSERVICE
+    description: "Switching service product block"
+    fields:
+      - name: switching_service_id
+        description: "Unique NSI switching service identifier"
+        type: str
+        required: provisioning
+      - name: switching_service_name
+        description: "Switching service name"
+        type: str
+        required: provisioning
+        modifiable: true
+      - name: topology
+        description: "Topology this switching service is part of"
+        type: Topology
+        required: provisioning

--- a/tests/test_dds_proxy.py
+++ b/tests/test_dds_proxy.py
@@ -45,9 +45,7 @@ def test_client_kwargs_dev_headers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(dds_proxy.settings, "dds_proxy_auth_method", "x509")
     monkeypatch.setattr(dds_proxy.settings, "dds_proxy_client_dn", "CN=test")
 
-    assert dds_proxy._client_kwargs() == {
-        "headers": {"X-Auth-Method": "x509", "X-Client-DN": "CN=test"}
-    }
+    assert dds_proxy._client_kwargs() == {"headers": {"X-Auth-Method": "x509", "X-Client-DN": "CN=test"}}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_switchingservice.py
+++ b/tests/test_switchingservice.py
@@ -40,9 +40,7 @@ def test_dds_switchingservice_parses_camelcase_topology_id() -> None:
 
 
 def test_switchingservice_selector_keys_and_labels_by_id() -> None:
-    enum = forms.switchingservice_selector(
-        [DdsSwitchingService(id="a", topology_id="t1")]
-    )
+    enum = forms.switchingservice_selector([DdsSwitchingService(id="a", topology_id="t1")])
 
     assert {member.value: member.label for member in enum} == {"a": "a"}
 
@@ -59,12 +57,8 @@ def test_available_switching_services_excludes_subscribed_and_requires_subscribe
         "fetch_switching_services",
         lambda: [
             DdsSwitchingService(id="ss-x", topology_id="topo-1"),  # already subscribed
-            DdsSwitchingService(
-                id="ss-y", topology_id="topo-1"
-            ),  # topology subscribed -> offered
-            DdsSwitchingService(
-                id="ss-z", topology_id="topo-2"
-            ),  # topology not subscribed
+            DdsSwitchingService(id="ss-y", topology_id="topo-1"),  # topology subscribed -> offered
+            DdsSwitchingService(id="ss-z", topology_id="topo-2"),  # topology not subscribed
         ],
     )
 

--- a/tests/test_switchingservice.py
+++ b/tests/test_switchingservice.py
@@ -1,0 +1,81 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the switching service client model, form helpers and description."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from products.product_types.switchingservice import SwitchingServiceProvisioning
+from products.services.description import description
+from services.dds_proxy import DdsSwitchingService
+from workflows.switchingservice.shared import forms
+
+
+def test_dds_switchingservice_parses_camelcase_topology_id() -> None:
+    service = DdsSwitchingService.model_validate(
+        {
+            "id": "ss-1",
+            "encoding": "e",
+            "labelSwapping": True,
+            "labelType": "l",
+            "topologyId": "topo-1",
+        }
+    )
+
+    assert (service.id, service.topology_id) == ("ss-1", "topo-1")
+
+
+def test_switchingservice_selector_keys_and_labels_by_id() -> None:
+    enum = forms.switchingservice_selector(
+        [DdsSwitchingService(id="a", topology_id="t1")]
+    )
+
+    assert {member.value: member.label for member in enum} == {"a": "a"}
+
+
+def test_available_switching_services_excludes_subscribed_and_requires_subscribed_topology(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_subscribed(product_type: str, resource_type: str) -> set[str]:
+        return {"ss-x"} if product_type == "SwitchingService" else {"topo-1"}
+
+    monkeypatch.setattr(forms, "subscribed_values", fake_subscribed)
+    monkeypatch.setattr(
+        forms,
+        "fetch_switching_services",
+        lambda: [
+            DdsSwitchingService(id="ss-x", topology_id="topo-1"),  # already subscribed
+            DdsSwitchingService(
+                id="ss-y", topology_id="topo-1"
+            ),  # topology subscribed -> offered
+            DdsSwitchingService(
+                id="ss-z", topology_id="topo-2"
+            ),  # topology not subscribed
+        ],
+    )
+
+    assert [service.id for service in forms.available_switching_services()] == ["ss-y"]
+
+
+def test_switchingservice_description_uses_product_name_and_service_name() -> None:
+    switchingservice_description = description.dispatch(SwitchingServiceProvisioning)
+    stub = SimpleNamespace(
+        product=SimpleNamespace(name="switchingservice"),
+        switchingservice=SimpleNamespace(switching_service_name="Core SS"),
+    )
+
+    assert switchingservice_description(stub) == "switchingservice Core SS"

--- a/translations/en-GB.json
+++ b/translations/en-GB.json
@@ -1,14 +1,21 @@
 {
     "forms": {
         "fields": {
+            "switching_service_id": "Switching service",
+            "switching_service_id_info": "Select the switching service to create a subscription for",
+            "switching_service_name": "Switching service name",
             "topology": "Topology",
             "topology_info": "Select the topology to create a subscription for"
         }
     },
     "workflow": {
+        "create_switchingservice": "Create switching service",
         "create_topology": "Create topology",
+        "modify_switchingservice": "Modify switching service",
         "modify_topology": "Modify topology",
+        "terminate_switchingservice": "Terminate switching service",
         "terminate_topology": "Terminate topology",
+        "validate_switchingservice": "Validate switching service",
         "validate_topology": "Validate topology"
     }
 }

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -17,3 +17,17 @@ LazyWorkflowInstance("workflows.topology.create_topology", "create_topology")
 LazyWorkflowInstance("workflows.topology.modify_topology", "modify_topology")
 LazyWorkflowInstance("workflows.topology.terminate_topology", "terminate_topology")
 LazyWorkflowInstance("workflows.topology.validate_topology", "validate_topology")
+
+LazyWorkflowInstance(
+    "workflows.switchingservice.create_switchingservice", "create_switchingservice"
+)
+LazyWorkflowInstance(
+    "workflows.switchingservice.modify_switchingservice", "modify_switchingservice"
+)
+LazyWorkflowInstance(
+    "workflows.switchingservice.terminate_switchingservice",
+    "terminate_switchingservice",
+)
+LazyWorkflowInstance(
+    "workflows.switchingservice.validate_switchingservice", "validate_switchingservice"
+)

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -18,16 +18,10 @@ LazyWorkflowInstance("workflows.topology.modify_topology", "modify_topology")
 LazyWorkflowInstance("workflows.topology.terminate_topology", "terminate_topology")
 LazyWorkflowInstance("workflows.topology.validate_topology", "validate_topology")
 
-LazyWorkflowInstance(
-    "workflows.switchingservice.create_switchingservice", "create_switchingservice"
-)
-LazyWorkflowInstance(
-    "workflows.switchingservice.modify_switchingservice", "modify_switchingservice"
-)
+LazyWorkflowInstance("workflows.switchingservice.create_switchingservice", "create_switchingservice")
+LazyWorkflowInstance("workflows.switchingservice.modify_switchingservice", "modify_switchingservice")
 LazyWorkflowInstance(
     "workflows.switchingservice.terminate_switchingservice",
     "terminate_switchingservice",
 )
-LazyWorkflowInstance(
-    "workflows.switchingservice.validate_switchingservice", "validate_switchingservice"
-)
+LazyWorkflowInstance("workflows.switchingservice.validate_switchingservice", "validate_switchingservice")

--- a/workflows/shared.py
+++ b/workflows/shared.py
@@ -43,16 +43,12 @@ def summary_form(product_name: str, summary_data: dict) -> Generator:
     yield SummaryForm
 
 
-def create_summary_form(
-    user_input: dict, product_name: str, fields: list[str]
-) -> Generator:
+def create_summary_form(user_input: dict, product_name: str, fields: list[str]) -> Generator:
     columns = [[str(user_input[nm]) for nm in fields]]
     yield from summary_form(product_name, {"labels": fields, "columns": columns})
 
 
-def modify_summary_form(
-    user_input: dict, block: ProductBlockModel, fields: list[str]
-) -> Generator:
+def modify_summary_form(user_input: dict, block: ProductBlockModel, fields: list[str]) -> Generator:
     before = [str(getattr(block, nm)) for nm in fields]
     after = [str(user_input[nm]) for nm in fields]
     yield from summary_form(
@@ -72,8 +68,7 @@ def _value_select(column: Any, product_type: str, resource_type: str) -> Select:
         .select_from(SubscriptionInstanceValueTable)
         .join(
             ResourceTypeTable,
-            SubscriptionInstanceValueTable.resource_type_id
-            == ResourceTypeTable.resource_type_id,
+            SubscriptionInstanceValueTable.resource_type_id == ResourceTypeTable.resource_type_id,
         )
         .join(
             SubscriptionInstanceTable,
@@ -82,8 +77,7 @@ def _value_select(column: Any, product_type: str, resource_type: str) -> Select:
         )
         .join(
             SubscriptionTable,
-            SubscriptionInstanceTable.subscription_id
-            == SubscriptionTable.subscription_id,
+            SubscriptionInstanceTable.subscription_id == SubscriptionTable.subscription_id,
         )
         .join(ProductTable, SubscriptionTable.product_id == ProductTable.product_id)
         .where(ProductTable.product_type == product_type)
@@ -94,21 +88,13 @@ def _value_select(column: Any, product_type: str, resource_type: str) -> Select:
 
 def subscribed_values(product_type: str, resource_type: str) -> set[str]:
     """Return the ``resource_type`` values across non-terminated ``product_type`` subscriptions."""
-    return set(
-        db.session.scalars(
-            _value_select(
-                SubscriptionInstanceValueTable.value, product_type, resource_type
-            )
-        )
-    )
+    return set(db.session.scalars(_value_select(SubscriptionInstanceValueTable.value, product_type, resource_type)))
 
 
-def subscription_id_for_value(
-    product_type: str, resource_type: str, value: str
-) -> UUID | None:
+def subscription_id_for_value(product_type: str, resource_type: str, value: str) -> UUID | None:
     """Return the subscription id whose ``resource_type`` equals ``value`` (first match), or None."""
-    query = _value_select(
-        SubscriptionTable.subscription_id, product_type, resource_type
-    ).where(SubscriptionInstanceValueTable.value == value)
+    query = _value_select(SubscriptionTable.subscription_id, product_type, resource_type).where(
+        SubscriptionInstanceValueTable.value == value
+    )
     result: UUID | None = db.session.scalars(query).first()
     return result

--- a/workflows/shared.py
+++ b/workflows/shared.py
@@ -12,12 +12,23 @@
 # limitations under the License.
 
 from collections.abc import Generator
-from typing import TypeAlias, cast
+from typing import Any, TypeAlias, cast
+from uuid import UUID
 
+from orchestrator.core.db import (
+    ProductTable,
+    ResourceTypeTable,
+    SubscriptionInstanceTable,
+    SubscriptionInstanceValueTable,
+    SubscriptionTable,
+    db,
+)
 from orchestrator.core.domain.base import ProductBlockModel
 from orchestrator.core.forms import FormPage
 from orchestrator.core.forms.validators import MigrationSummary, migration_summary
+from orchestrator.core.types import SubscriptionLifecycle
 from pydantic import ConfigDict
+from sqlalchemy import Select, select
 
 
 def summary_form(product_name: str, summary_data: dict) -> Generator:
@@ -52,3 +63,52 @@ def modify_summary_form(
             "columns": [before, after],
         },
     )
+
+
+def _value_select(column: Any, product_type: str, resource_type: str) -> Select:
+    """Select ``column`` for a resource type across non-terminated subscriptions of a product type."""
+    return (
+        select(column)
+        .select_from(SubscriptionInstanceValueTable)
+        .join(
+            ResourceTypeTable,
+            SubscriptionInstanceValueTable.resource_type_id
+            == ResourceTypeTable.resource_type_id,
+        )
+        .join(
+            SubscriptionInstanceTable,
+            SubscriptionInstanceValueTable.subscription_instance_id
+            == SubscriptionInstanceTable.subscription_instance_id,
+        )
+        .join(
+            SubscriptionTable,
+            SubscriptionInstanceTable.subscription_id
+            == SubscriptionTable.subscription_id,
+        )
+        .join(ProductTable, SubscriptionTable.product_id == ProductTable.product_id)
+        .where(ProductTable.product_type == product_type)
+        .where(ResourceTypeTable.resource_type == resource_type)
+        .where(SubscriptionTable.status != SubscriptionLifecycle.TERMINATED)
+    )
+
+
+def subscribed_values(product_type: str, resource_type: str) -> set[str]:
+    """Return the ``resource_type`` values across non-terminated ``product_type`` subscriptions."""
+    return set(
+        db.session.scalars(
+            _value_select(
+                SubscriptionInstanceValueTable.value, product_type, resource_type
+            )
+        )
+    )
+
+
+def subscription_id_for_value(
+    product_type: str, resource_type: str, value: str
+) -> UUID | None:
+    """Return the subscription id whose ``resource_type`` equals ``value`` (first match), or None."""
+    query = _value_select(
+        SubscriptionTable.subscription_id, product_type, resource_type
+    ).where(SubscriptionInstanceValueTable.value == value)
+    result: UUID | None = db.session.scalars(query).first()
+    return result

--- a/workflows/switchingservice/__init__.py
+++ b/workflows/switchingservice/__init__.py
@@ -10,15 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
-
-from products.product_types.switchingservice import SwitchingService
-from products.product_types.topology import Topology
-
-SUBSCRIPTION_MODEL_REGISTRY.update(
-    {
-        "topology": Topology,
-        "switchingservice": SwitchingService,
-        },
-)  # fmt:skip

--- a/workflows/switchingservice/create_switchingservice.py
+++ b/workflows/switchingservice/create_switchingservice.py
@@ -96,8 +96,6 @@ def construct_switchingservice_model(
 additional_steps = begin
 
 
-@create_workflow(
-    initial_input_form=initial_input_form_generator, additional_steps=additional_steps
-)
+@create_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_switchingservice() -> StepList:
     return begin >> construct_switchingservice_model >> store_process_subscription()

--- a/workflows/switchingservice/create_switchingservice.py
+++ b/workflows/switchingservice/create_switchingservice.py
@@ -1,0 +1,103 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.forms import FormPage
+from orchestrator.core.settings import app_settings
+from orchestrator.core.types import SubscriptionLifecycle
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.steps import store_process_subscription
+from orchestrator.core.workflows.utils import create_workflow
+from pydantic import ConfigDict
+from pydantic_forms.types import FormGenerator, State, UUIDstr
+
+from products.product_types.switchingservice import (
+    SwitchingServiceInactive,
+    SwitchingServiceProvisioning,
+)
+from products.services.description import description
+from workflows.shared import create_summary_form
+from workflows.switchingservice.shared.forms import (
+    available_switching_services,
+    switchingservice_selector,
+    topology_block_for,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def initial_input_form_generator(product_name: str) -> FormGenerator:
+    # Only services without a subscription whose topology is already subscribed, so the topology
+    # link in the construct step always resolves.
+    services = available_switching_services()
+    topology_id_by_id = {service.id: service.topology_id for service in services}
+    SwitchingServiceChoice = switchingservice_selector(services)
+
+    class CreateSwitchingServiceForm(FormPage):
+        model_config = ConfigDict(title=product_name)
+
+        switching_service_id: SwitchingServiceChoice  # type: ignore[valid-type]
+        switching_service_name: str
+
+    user_input = yield CreateSwitchingServiceForm
+    user_input_dict = user_input.model_dump()
+    switching_service_id = user_input_dict["switching_service_id"]
+
+    summary_fields = ["switching_service_id", "switching_service_name"]
+    yield from create_summary_form(user_input_dict, product_name, summary_fields)
+
+    return {
+        "customer_id": app_settings.DEFAULT_CUSTOMER_IDENTIFIER,
+        "switching_service_id": switching_service_id,
+        "switching_service_name": user_input_dict["switching_service_name"],
+        "topology_id": topology_id_by_id[switching_service_id],
+    }
+
+
+@step("Construct Subscription model")
+def construct_switchingservice_model(
+    product: UUIDstr,
+    customer_id: UUIDstr,
+    switching_service_id: str,
+    switching_service_name: str,
+    topology_id: str,
+) -> State:
+    switchingservice = SwitchingServiceInactive.from_product_id(
+        product_id=product,
+        customer_id=customer_id,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    switchingservice.switchingservice.switching_service_id = switching_service_id
+    switchingservice.switchingservice.switching_service_name = switching_service_name
+    switchingservice.switchingservice.topology = topology_block_for(topology_id)
+
+    switchingservice = SwitchingServiceProvisioning.from_other_lifecycle(
+        switchingservice, SubscriptionLifecycle.PROVISIONING
+    )
+    switchingservice.description = description(switchingservice)
+
+    return {
+        "subscription": switchingservice,
+        "subscription_id": switchingservice.subscription_id,
+        "subscription_description": switchingservice.description,
+    }
+
+
+additional_steps = begin
+
+
+@create_workflow(
+    initial_input_form=initial_input_form_generator, additional_steps=additional_steps
+)
+def create_switchingservice() -> StepList:
+    return begin >> construct_switchingservice_model >> store_process_subscription()

--- a/workflows/switchingservice/modify_switchingservice.py
+++ b/workflows/switchingservice/modify_switchingservice.py
@@ -42,17 +42,13 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
     user_input_dict: State = user_input.model_dump()
 
     summary_fields = ["switching_service_id", "switching_service_name"]
-    yield from modify_summary_form(
-        user_input_dict, subscription.switchingservice, summary_fields
-    )
+    yield from modify_summary_form(user_input_dict, subscription.switchingservice, summary_fields)
 
     return user_input_dict | {"subscription": subscription}
 
 
 @step("Update subscription")
-def update_subscription(
-    subscription: SwitchingServiceProvisioning, switching_service_name: str
-) -> State:
+def update_subscription(subscription: SwitchingServiceProvisioning, switching_service_name: str) -> State:
     subscription.switchingservice.switching_service_name = switching_service_name
     return {"subscription": subscription}
 
@@ -66,9 +62,7 @@ def update_subscription_description(subscription: SwitchingService) -> State:
 additional_steps = begin
 
 
-@modify_workflow(
-    initial_input_form=initial_input_form_generator, additional_steps=additional_steps
-)
+@modify_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def modify_switchingservice() -> StepList:
     return (
         begin

--- a/workflows/switchingservice/modify_switchingservice.py
+++ b/workflows/switchingservice/modify_switchingservice.py
@@ -1,0 +1,79 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.forms import FormPage
+from orchestrator.core.types import SubscriptionLifecycle
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.steps import set_status
+from orchestrator.core.workflows.utils import modify_workflow
+from pydantic_forms.types import FormGenerator, State, UUIDstr
+from pydantic_forms.validators import read_only_field
+
+from products.product_types.switchingservice import (
+    SwitchingService,
+    SwitchingServiceProvisioning,
+)
+from products.services.description import description
+from workflows.shared import modify_summary_form
+
+logger = structlog.get_logger(__name__)
+
+
+def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
+    subscription = SwitchingService.from_subscription(subscription_id)
+    switchingservice = subscription.switchingservice
+
+    class ModifySwitchingServiceForm(FormPage):
+        switching_service_id: read_only_field(switchingservice.switching_service_id)  # type: ignore[valid-type]
+        switching_service_name: str = switchingservice.switching_service_name
+
+    user_input = yield ModifySwitchingServiceForm
+    user_input_dict: State = user_input.model_dump()
+
+    summary_fields = ["switching_service_id", "switching_service_name"]
+    yield from modify_summary_form(
+        user_input_dict, subscription.switchingservice, summary_fields
+    )
+
+    return user_input_dict | {"subscription": subscription}
+
+
+@step("Update subscription")
+def update_subscription(
+    subscription: SwitchingServiceProvisioning, switching_service_name: str
+) -> State:
+    subscription.switchingservice.switching_service_name = switching_service_name
+    return {"subscription": subscription}
+
+
+@step("Update subscription description")
+def update_subscription_description(subscription: SwitchingService) -> State:
+    subscription.description = description(subscription)
+    return {"subscription": subscription}
+
+
+additional_steps = begin
+
+
+@modify_workflow(
+    initial_input_form=initial_input_form_generator, additional_steps=additional_steps
+)
+def modify_switchingservice() -> StepList:
+    return (
+        begin
+        >> set_status(SubscriptionLifecycle.PROVISIONING)
+        >> update_subscription
+        >> update_subscription_description
+        >> set_status(SubscriptionLifecycle.ACTIVE)
+    )

--- a/workflows/switchingservice/shared/__init__.py
+++ b/workflows/switchingservice/shared/__init__.py
@@ -10,15 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
-
-from products.product_types.switchingservice import SwitchingService
-from products.product_types.topology import Topology
-
-SUBSCRIPTION_MODEL_REGISTRY.update(
-    {
-        "topology": Topology,
-        "switchingservice": SwitchingService,
-        },
-)  # fmt:skip

--- a/workflows/switchingservice/shared/forms.py
+++ b/workflows/switchingservice/shared/forms.py
@@ -1,0 +1,49 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared form helpers for the switching service workflows."""
+
+from typing import cast
+
+from pydantic_forms.validators import Choice
+
+from products.product_blocks.topology import TopologyBlock
+from products.product_types.topology import Topology
+from services.dds_proxy import DdsSwitchingService, fetch_switching_services
+from workflows.shared import subscribed_values, subscription_id_for_value
+
+
+def available_switching_services() -> list[DdsSwitchingService]:
+    """dds-proxy switching services without a subscription whose topology is already subscribed."""
+    subscribed = subscribed_values("SwitchingService", "switching_service_id")
+    topologies = subscribed_values("Topology", "topology_id")
+    return [
+        service
+        for service in fetch_switching_services()
+        if service.id not in subscribed and service.topology_id in topologies
+    ]
+
+
+def switchingservice_selector(services: list[DdsSwitchingService]) -> type[Choice]:
+    """Build a dropdown of ``services``, keyed and labelled by ``switching_service_id``."""
+    options = {service.id: service.id for service in services}
+    choices = Choice("SwitchingService", zip(options.keys(), options.items()))  # type: ignore[arg-type]
+    return cast("type[Choice]", choices)
+
+
+def topology_block_for(topology_id: str) -> TopologyBlock:
+    """Return the TopologyBlock of the subscription that owns ``topology_id``."""
+    subscription_id = subscription_id_for_value("Topology", "topology_id", topology_id)
+    # never None: available_switching_services only offers services whose topology is subscribed
+    assert subscription_id is not None
+    return Topology.from_subscription(subscription_id).topology

--- a/workflows/switchingservice/terminate_switchingservice.py
+++ b/workflows/switchingservice/terminate_switchingservice.py
@@ -1,0 +1,50 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.forms import FormPage
+from orchestrator.core.forms.validators import DisplaySubscription
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.utils import terminate_workflow
+from pydantic_forms.types import InputForm, State, UUIDstr
+
+from products.product_types.switchingservice import SwitchingService
+
+logger = structlog.get_logger(__name__)
+
+
+def terminate_initial_input_form_generator(
+    subscription_id: UUIDstr, customer_id: UUIDstr
+) -> InputForm:
+    temp_subscription_id = subscription_id
+
+    class TerminateSwitchingServiceForm(FormPage):
+        subscription_id: DisplaySubscription = temp_subscription_id  # type: ignore[assignment]
+
+    return TerminateSwitchingServiceForm
+
+
+@step("Terminate switching service subscription")
+def terminate_switchingservice_subscription(subscription: SwitchingService) -> State:
+    # DDS is read-only, so there is nothing to deprovision; just drop the subscription.
+    logger.info(
+        "Terminating switching service subscription",
+        switching_service_id=subscription.switchingservice.switching_service_id,
+    )
+
+    return {}
+
+
+@terminate_workflow(initial_input_form=terminate_initial_input_form_generator)
+def terminate_switchingservice() -> StepList:
+    return begin >> terminate_switchingservice_subscription

--- a/workflows/switchingservice/terminate_switchingservice.py
+++ b/workflows/switchingservice/terminate_switchingservice.py
@@ -23,9 +23,7 @@ from products.product_types.switchingservice import SwitchingService
 logger = structlog.get_logger(__name__)
 
 
-def terminate_initial_input_form_generator(
-    subscription_id: UUIDstr, customer_id: UUIDstr
-) -> InputForm:
+def terminate_initial_input_form_generator(subscription_id: UUIDstr, customer_id: UUIDstr) -> InputForm:
     temp_subscription_id = subscription_id
 
     class TerminateSwitchingServiceForm(FormPage):

--- a/workflows/switchingservice/validate_switchingservice.py
+++ b/workflows/switchingservice/validate_switchingservice.py
@@ -1,0 +1,41 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.utils import validate_workflow
+from pydantic_forms.types import State
+
+from products.product_types.switchingservice import SwitchingService
+from services.dds_proxy import fetch_switching_services
+
+logger = structlog.get_logger(__name__)
+
+
+@step("Validate switching service is still present in the DDS")
+def validate_switchingservice_present_in_dds(subscription: SwitchingService) -> State:
+    """Assert the subscription's switching_service_id is still advertised by the dds-proxy."""
+    switching_service_id = subscription.switchingservice.switching_service_id
+    known_ids = {service.id for service in fetch_switching_services()}
+    if switching_service_id not in known_ids:
+        raise AssertionError(
+            f"Switching service {switching_service_id} is no longer present in the dds-proxy "
+            "/switching-services endpoint"
+        )
+
+    return {"subscription": subscription}
+
+
+@validate_workflow()
+def validate_switchingservice() -> StepList:
+    return begin >> validate_switchingservice_present_in_dds

--- a/workflows/topology/create_topology.py
+++ b/workflows/topology/create_topology.py
@@ -46,9 +46,7 @@ def initial_input_form_generator(product_name: str) -> FormGenerator:
     topology_name = topology_name_by_id[topology_id]
 
     summary_data = {"topology_id": topology_id, "topology_name": topology_name}
-    yield from create_summary_form(
-        summary_data, product_name, ["topology_id", "topology_name"]
-    )
+    yield from create_summary_form(summary_data, product_name, ["topology_id", "topology_name"])
 
     # No CRM for this orchestrator: use orchestrator-core's configurable default customer
     # (override with the DEFAULT_CUSTOMER_IDENTIFIER env var) instead of asking on the form.
@@ -74,9 +72,7 @@ def construct_topology_model(
     topology.topology.topology_id = topology_id
     topology.topology.topology_name = topology_name
 
-    topology = TopologyProvisioning.from_other_lifecycle(
-        topology, SubscriptionLifecycle.PROVISIONING
-    )
+    topology = TopologyProvisioning.from_other_lifecycle(topology, SubscriptionLifecycle.PROVISIONING)
     topology.description = description(topology)
 
     return {
@@ -89,8 +85,6 @@ def construct_topology_model(
 additional_steps = begin
 
 
-@create_workflow(
-    initial_input_form=initial_input_form_generator, additional_steps=additional_steps
-)
+@create_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def create_topology() -> StepList:
     return begin >> construct_topology_model >> store_process_subscription()

--- a/workflows/topology/create_topology.py
+++ b/workflows/topology/create_topology.py
@@ -32,12 +32,6 @@ logger = structlog.get_logger(__name__)
 def initial_input_form_generator(product_name: str) -> FormGenerator:
     # Offer the topologies known to the dds-proxy that do not yet have a subscription.
     topologies = available_topologies()
-    if not topologies:
-        raise ValueError(
-            "No topologies available to subscribe to: every topology known to the dds-proxy "
-            "already has a subscription."
-        )
-
     topology_name_by_id = {topology.id: topology.name for topology in topologies}
     TopologyChoice = topology_selector(topologies)
 

--- a/workflows/topology/modify_topology.py
+++ b/workflows/topology/modify_topology.py
@@ -39,9 +39,7 @@ def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
     user_input_dict: State = user_input.model_dump()
 
     summary_fields = ["topology_id", "topology_name"]
-    yield from modify_summary_form(
-        user_input_dict, subscription.topology, summary_fields
-    )
+    yield from modify_summary_form(user_input_dict, subscription.topology, summary_fields)
 
     return user_input_dict | {"subscription": subscription}
 
@@ -65,9 +63,7 @@ def update_subscription_description(subscription: Topology) -> State:
 additional_steps = begin
 
 
-@modify_workflow(
-    initial_input_form=initial_input_form_generator, additional_steps=additional_steps
-)
+@modify_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
 def modify_topology() -> StepList:
     return (
         begin

--- a/workflows/topology/shared/forms.py
+++ b/workflows/topology/shared/forms.py
@@ -29,15 +29,11 @@ def subscribed_topology_ids() -> set[str]:
 def available_topologies() -> list[DdsTopology]:
     """Return the dds-proxy topologies that do not yet have a subscription."""
     subscribed = subscribed_topology_ids()
-    return [
-        topology for topology in fetch_topologies() if topology.id not in subscribed
-    ]
+    return [topology for topology in fetch_topologies() if topology.id not in subscribed]
 
 
 def topology_selector(topologies: list[DdsTopology]) -> type[Choice]:
     """Build a dropdown of ``topologies``, keyed by ``topology_id`` and labelled ``name (id)``."""
-    options = {
-        topology.id: f"{topology.name} ({topology.id})" for topology in topologies
-    }
+    options = {topology.id: f"{topology.name} ({topology.id})" for topology in topologies}
     choices = Choice("TopologyChoice", zip(options.keys(), options.items()))  # type: ignore[arg-type]
     return cast("type[Choice]", choices)

--- a/workflows/topology/shared/forms.py
+++ b/workflows/topology/shared/forms.py
@@ -15,46 +15,15 @@
 
 from typing import cast
 
-from orchestrator.core.db import (
-    ProductTable,
-    ResourceTypeTable,
-    SubscriptionInstanceTable,
-    SubscriptionInstanceValueTable,
-    SubscriptionTable,
-    db,
-)
-from orchestrator.core.types import SubscriptionLifecycle
 from pydantic_forms.validators import Choice
-from sqlalchemy import select
 
 from services.dds_proxy import DdsTopology, fetch_topologies
+from workflows.shared import subscribed_values
 
 
 def subscribed_topology_ids() -> set[str]:
     """Return the ``topology_id`` values that already have a non-terminated Topology subscription."""
-    query = (
-        select(SubscriptionInstanceValueTable.value)
-        .join(
-            ResourceTypeTable,
-            SubscriptionInstanceValueTable.resource_type_id
-            == ResourceTypeTable.resource_type_id,
-        )
-        .join(
-            SubscriptionInstanceTable,
-            SubscriptionInstanceValueTable.subscription_instance_id
-            == SubscriptionInstanceTable.subscription_instance_id,
-        )
-        .join(
-            SubscriptionTable,
-            SubscriptionInstanceTable.subscription_id
-            == SubscriptionTable.subscription_id,
-        )
-        .join(ProductTable, SubscriptionTable.product_id == ProductTable.product_id)
-        .where(ProductTable.product_type == "Topology")
-        .where(ResourceTypeTable.resource_type == "topology_id")
-        .where(SubscriptionTable.status != SubscriptionLifecycle.TERMINATED)
-    )
-    return set(db.session.scalars(query))
+    return subscribed_values("Topology", "topology_id")
 
 
 def available_topologies() -> list[DdsTopology]:

--- a/workflows/topology/terminate_topology.py
+++ b/workflows/topology/terminate_topology.py
@@ -23,9 +23,7 @@ from products.product_types.topology import Topology
 logger = structlog.get_logger(__name__)
 
 
-def terminate_initial_input_form_generator(
-    subscription_id: UUIDstr, customer_id: UUIDstr
-) -> InputForm:
+def terminate_initial_input_form_generator(subscription_id: UUIDstr, customer_id: UUIDstr) -> InputForm:
     temp_subscription_id = subscription_id
 
     class TerminateTopologyForm(FormPage):

--- a/workflows/topology/validate_topology.py
+++ b/workflows/topology/validate_topology.py
@@ -28,9 +28,7 @@ def validate_topology_present_in_dds(subscription: Topology) -> State:
     topology_id = subscription.topology.topology_id
     known_topology_ids = {topology.id for topology in fetch_topologies()}
     if topology_id not in known_topology_ids:
-        raise AssertionError(
-            f"Topology {topology_id} is no longer present in the dds-proxy /topologies endpoint"
-        )
+        raise AssertionError(f"Topology {topology_id} is no longer present in the dds-proxy /topologies endpoint")
 
     return {"subscription": subscription}
 


### PR DESCRIPTION
Implements #4 — a **SwitchingService** product (mirrors the Topology product) backed by the
nsi-dds-proxy and linked to an existing topology.

## What's included
- SwitchingService product + product block (`switching_service_id`, modifiable
  `switching_service_name`, and a `topology` link to the existing `TopologyBlock`) and the
  create/modify/validate/terminate workflows, plus the migration registering them with a
  `depends_on` on the Topology block.
- **create** — dropdown of dds-proxy `GET /switching-services` ids that have no subscription yet
  and whose topology is already subscribed; links the chosen service to that topology's block;
  uses the default customer (no Customer Id field).
- **modify** — change `switching_service_name`. **validate** — assert `switching_service_id` is
  still advertised by the dds-proxy. **terminate** — drop the subscription.
- `DdsSwitchingService` + `fetch_switching_services()` on the dds-proxy client (camelCase aliases),
  extracted onto a shared `_fetch()` helper.
- Generic `subscribed_values()` / `subscription_id_for_value()` in `workflows/shared.py`; the
  topology query was collapsed onto them.
- Registered the description, product-block title, the product, the workflows, and en-GB
  translations.
- Create forms now render an empty dropdown instead of erroring when nothing is available (applies
  to topology create too).

## Verification
- `ruff` / `ruff format --check` / `mypy .` (37 files) / `pytest` (16 passed) all green.
- Migration applied to the local nsi DB (`13e35d8ae1ed -> e9c7f020ab00`); `wsgi` loads with both
  products and all four switching-service workflows registered.
- dds-proxy parsing/selector/availability-filter/description covered by unit tests; the live
  `/switching-services` route 404s on the currently deployed proxy, so it's exercised via mocks.

Closes #4