### PR TITLE
Add service termination point product and workflows

### DIFF
--- a/migrations/versions/schema/2026-06-22_b66721b43c63_add_stp.py
+++ b/migrations/versions/schema/2026-06-22_b66721b43c63_add_stp.py
@@ -1,0 +1,124 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Add stp product.
+
+Revision ID: b66721b43c63
+Revises: e9c7f020ab00
+Create Date: 2026-06-22 16:07:18.928406
+
+"""
+
+from uuid import uuid4
+
+from alembic import op
+from orchestrator.core.migrations.helpers import (
+    create,
+    create_workflow,
+    delete,
+    delete_workflow,
+    ensure_default_workflows,
+)
+from orchestrator.core.targets import Target
+
+# revision identifiers, used by Alembic.
+revision = "b66721b43c63"
+down_revision = "e9c7f020ab00"
+branch_labels = None
+depends_on = None
+
+new_products = {
+    "products": {
+        "stp": {
+            "product_id": uuid4(),
+            "product_type": "ServiceTerminationPoint",
+            "description": "Network Service Interface service termination point",
+            "tag": "STP",
+            "status": "active",
+            "root_product_block": "ServiceTerminationPoint",
+            "fixed_inputs": {},
+        },
+    },
+    "product_blocks": {
+        "ServiceTerminationPoint": {
+            "product_block_id": uuid4(),
+            "description": "Service termination point product block",
+            "tag": "STP",
+            "status": "active",
+            "resources": {
+                "stp_id": "Unique NSI service termination point identifier",
+                "stp_name": "Service termination point name",
+                "capacity": "The capacity of this service termination point",
+                "label_group": "The set of allowed labels for this service termination point",
+            },
+            "depends_on_block_relations": [
+                "SwitchingService",
+            ],
+        },
+    },
+    "workflows": {},
+}
+
+new_workflows = [
+    {
+        "name": "create_stp",
+        "target": Target.CREATE,
+        "is_task": False,
+        "description": "Create stp",
+        "product_type": "ServiceTerminationPoint",
+    },
+    {
+        "name": "modify_stp",
+        "target": Target.MODIFY,
+        "is_task": False,
+        "description": "Modify stp",
+        "product_type": "ServiceTerminationPoint",
+    },
+    {
+        "name": "terminate_stp",
+        "target": Target.TERMINATE,
+        "is_task": False,
+        "description": "Terminate stp",
+        "product_type": "ServiceTerminationPoint",
+    },
+    {
+        "name": "validate_stp",
+        "target": Target.VALIDATE,
+        "is_task": True,
+        "description": "Validate stp",
+        "product_type": "ServiceTerminationPoint",
+    },
+    {
+        "name": "reconcile_stp",
+        "target": Target.RECONCILE,
+        "is_task": False,
+        "description": "Reconcile stp",
+        "product_type": "ServiceTerminationPoint",
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    create(conn, new_products)
+    for workflow in new_workflows:
+        create_workflow(conn, workflow)
+    ensure_default_workflows(conn)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for workflow in new_workflows:
+        delete_workflow(conn, workflow["name"])
+
+    delete(conn, new_products)

--- a/products/product_blocks/stp.py
+++ b/products/product_blocks/stp.py
@@ -1,0 +1,54 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from orchestrator.core.domain.base import ProductBlockModel
+from orchestrator.core.types import SubscriptionLifecycle
+from pydantic import computed_field
+
+from products.product_blocks.switchingservice import (
+    SwitchingServiceBlock,
+    SwitchingServiceBlockInactive,
+    SwitchingServiceBlockProvisioning,
+)
+
+
+class ServiceTerminationPointBlockInactive(ProductBlockModel, product_block_name="ServiceTerminationPoint"):
+    stp_id: str | None = None
+    stp_name: str | None = None
+    capacity: int | None = None
+    label_group: str | None = None
+    switching_service: SwitchingServiceBlockInactive | None = None
+
+
+class ServiceTerminationPointBlockProvisioning(
+    ServiceTerminationPointBlockInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+):
+    stp_id: str
+    stp_name: str
+    capacity: int
+    label_group: str
+    switching_service: SwitchingServiceBlockProvisioning
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def title(self) -> str:
+        return f"stp {self.stp_id.removeprefix('urn:ogf:network:')}"
+
+
+class ServiceTerminationPointBlock(ServiceTerminationPointBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+    stp_id: str
+    stp_name: str
+    capacity: int
+    label_group: str
+    switching_service: SwitchingServiceBlock

--- a/products/product_blocks/switchingservice.py
+++ b/products/product_blocks/switchingservice.py
@@ -37,7 +37,7 @@ class SwitchingServiceBlockProvisioning(SwitchingServiceBlockInactive, lifecycle
     @computed_field  # type: ignore[prop-decorator]
     @property
     def title(self) -> str:
-        return f"SW {self.switching_service_id.removeprefix('urn:ogf:network:')}"
+        return f"sw {self.switching_service_id.removeprefix('urn:ogf:network:')}"
 
 
 class SwitchingServiceBlock(SwitchingServiceBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):

--- a/products/product_blocks/topology.py
+++ b/products/product_blocks/topology.py
@@ -29,7 +29,7 @@ class TopologyBlockProvisioning(TopologyBlockInactive, lifecycle=[SubscriptionLi
     @computed_field  # type: ignore[prop-decorator]
     @property
     def title(self) -> str:
-        return f"{self.name} {self.topology_id.removeprefix('urn:ogf:network:')}"
+        return f"topology {self.topology_id.removeprefix('urn:ogf:network:')}"
 
 
 class TopologyBlock(TopologyBlockProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):

--- a/products/product_types/stp.py
+++ b/products/product_types/stp.py
@@ -1,0 +1,36 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from orchestrator.core.domain.base import SubscriptionModel
+from orchestrator.core.types import SubscriptionLifecycle
+
+from products.product_blocks.stp import (
+    ServiceTerminationPointBlock,
+    ServiceTerminationPointBlockInactive,
+    ServiceTerminationPointBlockProvisioning,
+)
+
+
+class ServiceTerminationPointInactive(SubscriptionModel, is_base=True):
+    stp: ServiceTerminationPointBlockInactive
+
+
+class ServiceTerminationPointProvisioning(
+    ServiceTerminationPointInactive, lifecycle=[SubscriptionLifecycle.PROVISIONING]
+):
+    stp: ServiceTerminationPointBlockProvisioning
+
+
+class ServiceTerminationPoint(ServiceTerminationPointProvisioning, lifecycle=[SubscriptionLifecycle.ACTIVE]):
+    stp: ServiceTerminationPointBlock

--- a/products/services/description.py
+++ b/products/services/description.py
@@ -26,6 +26,7 @@ from orchestrator.core.domain.base import (
     SubscriptionModel,
 )
 
+from products.product_types.stp import ServiceTerminationPointProvisioning
 from products.product_types.switchingservice import SwitchingServiceProvisioning
 from products.product_types.topology import TopologyProvisioning
 
@@ -46,3 +47,8 @@ def _switchingservice_description(
     switchingservice: SwitchingServiceProvisioning,
 ) -> str:
     return f"{switchingservice.product.name} {switchingservice.switchingservice.switching_service_name}"
+
+
+@description.register
+def _stp_description(stp: ServiceTerminationPointProvisioning) -> str:
+    return f"{stp.product.name} {stp.stp.stp_name}"

--- a/services/dds_proxy.py
+++ b/services/dds_proxy.py
@@ -70,6 +70,21 @@ class DdsSwitchingService(BaseModel):
     topology_id: str
 
 
+class DdsServiceTerminationPoint(BaseModel):
+    """A service termination point from the dds-proxy ``GET /service-termination-points`` endpoint.
+
+    The proxy serialises with camelCase aliases (``labelGroup``, ``switchingServiceId``).
+    """
+
+    model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True, extra="ignore")
+
+    id: str
+    name: str
+    capacity: int
+    label_group: str
+    switching_service_id: str
+
+
 def _client_kwargs() -> dict[str, Any]:
     """Build the httpx client arguments for the configured authentication mode."""
     if settings.dds_proxy_mtls_enabled:
@@ -127,3 +142,8 @@ def fetch_topologies() -> list[DdsTopology]:
 def fetch_switching_services() -> list[DdsSwitchingService]:
     """Return all switching services known to the dds-proxy."""
     return [DdsSwitchingService.model_validate(item) for item in _fetch("/switching-services")]
+
+
+def fetch_service_termination_points() -> list[DdsServiceTerminationPoint]:
+    """Return all service termination points known to the dds-proxy."""
+    return [DdsServiceTerminationPoint.model_validate(item) for item in _fetch("/service-termination-points")]

--- a/stp.yaml
+++ b/stp.yaml
@@ -1,0 +1,33 @@
+config:
+  summary_forms: true
+name: stp
+type: ServiceTerminationPoint
+tag: STP
+description: "Network Service Interface service termination point"
+product_blocks:
+  - name: stp
+    type: ServiceTerminationPoint
+    tag: STP
+    description: "Service termination point product block"
+    fields:
+      - name: stp_id
+        description: "Unique NSI service termination point identifier"
+        type: str
+        required: provisioning
+      - name: stp_name
+        description: "Service termination point name"
+        type: str
+        required: provisioning
+        modifiable: true
+      - name: capacity
+        description: "The capacity of this service termination point"
+        type: int
+        required: provisioning
+      - name: label_group
+        description: "The set of allowed labels for this service termination point"
+        type: str
+        required: provisioning
+      - name: switching_service
+        description: "Switching service this service termination point is part of"
+        type: SwitchingService
+        required: provisioning

--- a/tests/test_stp.py
+++ b/tests/test_stp.py
@@ -1,0 +1,73 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the service termination point client model, form helpers and description."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from products.product_types.stp import ServiceTerminationPointProvisioning
+from products.services.description import description
+from services.dds_proxy import DdsServiceTerminationPoint
+from workflows.stp.shared import forms
+
+
+def test_dds_stp_parses_camelcase_aliases() -> None:
+    stp = DdsServiceTerminationPoint.model_validate(
+        {"id": "stp-1", "name": "STP 1", "capacity": 100, "labelGroup": "vlan", "switchingServiceId": "ss-1"}
+    )
+
+    assert (stp.id, stp.name, stp.capacity, stp.label_group, stp.switching_service_id) == (
+        "stp-1",
+        "STP 1",
+        100,
+        "vlan",
+        "ss-1",
+    )
+
+
+def test_stp_selector_keys_by_id_labels_by_name_and_id() -> None:
+    enum = forms.stp_selector(
+        [DdsServiceTerminationPoint(id="a", name="A", capacity=1, label_group="g", switching_service_id="s")]
+    )
+
+    assert {member.value: member.label for member in enum} == {"a": "A (a)"}
+
+
+def test_available_service_termination_points_excludes_subscribed_and_requires_switching_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_subscribed(product_type: str, resource_type: str) -> set[str]:
+        return {"stp-x"} if product_type == "ServiceTerminationPoint" else {"ss-1"}
+
+    def stp(id_: str, ss_id: str) -> DdsServiceTerminationPoint:
+        return DdsServiceTerminationPoint(id=id_, name=id_, capacity=1, label_group="g", switching_service_id=ss_id)
+
+    monkeypatch.setattr(forms, "subscribed_values", fake_subscribed)
+    monkeypatch.setattr(
+        forms,
+        "fetch_service_termination_points",
+        lambda: [stp("stp-x", "ss-1"), stp("stp-y", "ss-1"), stp("stp-z", "ss-2")],
+    )
+
+    assert [s.id for s in forms.available_service_termination_points()] == ["stp-y"]
+
+
+def test_stp_description_uses_product_name_and_stp_name() -> None:
+    stp_description = description.dispatch(ServiceTerminationPointProvisioning)
+    stub = SimpleNamespace(product=SimpleNamespace(name="stp"), stp=SimpleNamespace(stp_name="Core STP"))
+
+    assert stp_description(stub) == "stp Core STP"

--- a/translations/en-GB.json
+++ b/translations/en-GB.json
@@ -1,6 +1,11 @@
 {
     "forms": {
         "fields": {
+            "capacity": "Capacity",
+            "label_group": "Label group",
+            "stp_id": "Service termination point",
+            "stp_id_info": "Select the service termination point to create a subscription for",
+            "stp_name": "Service termination point name",
             "switching_service_id": "Switching service",
             "switching_service_id_info": "Select the switching service to create a subscription for",
             "switching_service_name": "Switching service name",
@@ -9,12 +14,17 @@
         }
     },
     "workflow": {
+        "create_stp": "Create service termination point",
         "create_switchingservice": "Create switching service",
         "create_topology": "Create topology",
+        "modify_stp": "Modify service termination point",
         "modify_switchingservice": "Modify switching service",
         "modify_topology": "Modify topology",
+        "reconcile_stp": "Reconcile service termination point",
+        "terminate_stp": "Terminate service termination point",
         "terminate_switchingservice": "Terminate switching service",
         "terminate_topology": "Terminate topology",
+        "validate_stp": "Validate service termination point",
         "validate_switchingservice": "Validate switching service",
         "validate_topology": "Validate topology"
     }

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -25,3 +25,9 @@ LazyWorkflowInstance(
     "terminate_switchingservice",
 )
 LazyWorkflowInstance("workflows.switchingservice.validate_switchingservice", "validate_switchingservice")
+
+LazyWorkflowInstance("workflows.stp.create_stp", "create_stp")
+LazyWorkflowInstance("workflows.stp.modify_stp", "modify_stp")
+LazyWorkflowInstance("workflows.stp.terminate_stp", "terminate_stp")
+LazyWorkflowInstance("workflows.stp.validate_stp", "validate_stp")
+LazyWorkflowInstance("workflows.stp.reconcile_stp", "reconcile_stp")

--- a/workflows/stp/__init__.py
+++ b/workflows/stp/__init__.py
@@ -10,17 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
-
-from products.product_types.stp import ServiceTerminationPoint
-from products.product_types.switchingservice import SwitchingService
-from products.product_types.topology import Topology
-
-SUBSCRIPTION_MODEL_REGISTRY.update(
-    {
-        "topology": Topology,
-        "switchingservice": SwitchingService,
-        "stp": ServiceTerminationPoint,
-        },
-)  # fmt:skip

--- a/workflows/stp/create_stp.py
+++ b/workflows/stp/create_stp.py
@@ -1,0 +1,108 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.forms import FormPage
+from orchestrator.core.settings import app_settings
+from orchestrator.core.types import SubscriptionLifecycle
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.steps import store_process_subscription
+from orchestrator.core.workflows.utils import create_workflow
+from pydantic import ConfigDict
+from pydantic_forms.types import FormGenerator, State, UUIDstr
+
+from products.product_types.stp import ServiceTerminationPointInactive, ServiceTerminationPointProvisioning
+from products.services.description import description
+from workflows.shared import create_summary_form
+from workflows.stp.shared.forms import (
+    available_service_termination_points,
+    stp_selector,
+    switchingservice_block_for,
+)
+
+logger = structlog.get_logger(__name__)
+
+
+def initial_input_form_generator(product_name: str) -> FormGenerator:
+    # Only STPs without a subscription whose switching service is already subscribed, so the
+    # switching_service link in the construct step always resolves.
+    stps = available_service_termination_points()
+    stp_by_id = {stp.id: stp for stp in stps}
+    ServiceTerminationPointChoice = stp_selector(stps)
+
+    class CreateServiceTerminationPointForm(FormPage):
+        model_config = ConfigDict(title=product_name)
+
+        stp_id: ServiceTerminationPointChoice  # type: ignore[valid-type]
+
+    user_input = yield CreateServiceTerminationPointForm
+    chosen = stp_by_id[user_input.model_dump()["stp_id"]]
+
+    summary_fields = ["stp_id", "stp_name", "capacity", "label_group"]
+    summary_data = {
+        "stp_id": chosen.id,
+        "stp_name": chosen.name,
+        "capacity": chosen.capacity,
+        "label_group": chosen.label_group,
+    }
+    yield from create_summary_form(summary_data, product_name, summary_fields)
+
+    # stp_name defaults to the DDS name (editable later via the modify workflow); the rest comes
+    # straight from the chosen DDS service termination point.
+    return {
+        "customer_id": app_settings.DEFAULT_CUSTOMER_IDENTIFIER,
+        "stp_id": chosen.id,
+        "stp_name": chosen.name,
+        "capacity": chosen.capacity,
+        "label_group": chosen.label_group,
+        "switching_service_id": chosen.switching_service_id,
+    }
+
+
+@step("Construct Subscription model")
+def construct_stp_model(
+    product: UUIDstr,
+    customer_id: UUIDstr,
+    stp_id: str,
+    stp_name: str,
+    capacity: int,
+    label_group: str,
+    switching_service_id: str,
+) -> State:
+    stp = ServiceTerminationPointInactive.from_product_id(
+        product_id=product,
+        customer_id=customer_id,
+        status=SubscriptionLifecycle.INITIAL,
+    )
+    stp.stp.stp_id = stp_id
+    stp.stp.stp_name = stp_name
+    stp.stp.capacity = capacity
+    stp.stp.label_group = label_group
+    stp.stp.switching_service = switchingservice_block_for(switching_service_id)
+
+    stp = ServiceTerminationPointProvisioning.from_other_lifecycle(stp, SubscriptionLifecycle.PROVISIONING)
+    stp.description = description(stp)
+
+    return {
+        "subscription": stp,
+        "subscription_id": stp.subscription_id,
+        "subscription_description": stp.description,
+    }
+
+
+additional_steps = begin
+
+
+@create_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
+def create_stp() -> StepList:
+    return begin >> construct_stp_model >> store_process_subscription()

--- a/workflows/stp/modify_stp.py
+++ b/workflows/stp/modify_stp.py
@@ -1,0 +1,70 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.forms import FormPage
+from orchestrator.core.types import SubscriptionLifecycle
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.steps import set_status
+from orchestrator.core.workflows.utils import modify_workflow
+from pydantic_forms.types import FormGenerator, State, UUIDstr
+from pydantic_forms.validators import read_only_field
+
+from products.product_types.stp import ServiceTerminationPoint, ServiceTerminationPointProvisioning
+from products.services.description import description
+from workflows.shared import modify_summary_form
+
+logger = structlog.get_logger(__name__)
+
+
+def initial_input_form_generator(subscription_id: UUIDstr) -> FormGenerator:
+    subscription = ServiceTerminationPoint.from_subscription(subscription_id)
+    stp = subscription.stp
+
+    class ModifyServiceTerminationPointForm(FormPage):
+        stp_id: read_only_field(stp.stp_id)  # type: ignore[valid-type]
+        stp_name: str = stp.stp_name
+
+    user_input = yield ModifyServiceTerminationPointForm
+    user_input_dict: State = user_input.model_dump()
+
+    summary_fields = ["stp_id", "stp_name"]
+    yield from modify_summary_form(user_input_dict, subscription.stp, summary_fields)
+
+    return user_input_dict | {"subscription": subscription}
+
+
+@step("Update subscription")
+def update_subscription(subscription: ServiceTerminationPointProvisioning, stp_name: str) -> State:
+    subscription.stp.stp_name = stp_name
+    return {"subscription": subscription}
+
+
+@step("Update subscription description")
+def update_subscription_description(subscription: ServiceTerminationPoint) -> State:
+    subscription.description = description(subscription)
+    return {"subscription": subscription}
+
+
+additional_steps = begin
+
+
+@modify_workflow(initial_input_form=initial_input_form_generator, additional_steps=additional_steps)
+def modify_stp() -> StepList:
+    return (
+        begin
+        >> set_status(SubscriptionLifecycle.PROVISIONING)
+        >> update_subscription
+        >> update_subscription_description
+        >> set_status(SubscriptionLifecycle.ACTIVE)
+    )

--- a/workflows/stp/reconcile_stp.py
+++ b/workflows/stp/reconcile_stp.py
@@ -1,0 +1,37 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.utils import reconcile_workflow
+from pydantic_forms.types import State
+
+from products.product_types.stp import ServiceTerminationPoint
+from services.dds_proxy import fetch_service_termination_points
+
+logger = structlog.get_logger(__name__)
+
+
+@step("Reconcile capacity from the DDS")
+def reconcile_capacity(subscription: ServiceTerminationPoint) -> State:
+    """Update capacity from the dds-proxy; leave it untouched if the STP is no longer advertised."""
+    capacity_by_id = {stp.id: stp.capacity for stp in fetch_service_termination_points()}
+    if subscription.stp.stp_id in capacity_by_id:
+        subscription.stp.capacity = capacity_by_id[subscription.stp.stp_id]
+
+    return {"subscription": subscription}
+
+
+@reconcile_workflow()
+def reconcile_stp() -> StepList:
+    return begin >> reconcile_capacity

--- a/workflows/stp/shared/__init__.py
+++ b/workflows/stp/shared/__init__.py
@@ -10,17 +10,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from orchestrator.core.domain import SUBSCRIPTION_MODEL_REGISTRY
-
-from products.product_types.stp import ServiceTerminationPoint
-from products.product_types.switchingservice import SwitchingService
-from products.product_types.topology import Topology
-
-SUBSCRIPTION_MODEL_REGISTRY.update(
-    {
-        "topology": Topology,
-        "switchingservice": SwitchingService,
-        "stp": ServiceTerminationPoint,
-        },
-)  # fmt:skip

--- a/workflows/stp/shared/forms.py
+++ b/workflows/stp/shared/forms.py
@@ -1,0 +1,49 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared form helpers for the service termination point workflows."""
+
+from typing import cast
+
+from pydantic_forms.validators import Choice
+
+from products.product_blocks.switchingservice import SwitchingServiceBlock
+from products.product_types.switchingservice import SwitchingService
+from services.dds_proxy import DdsServiceTerminationPoint, fetch_service_termination_points
+from workflows.shared import subscribed_values, subscription_id_for_value
+
+
+def available_service_termination_points() -> list[DdsServiceTerminationPoint]:
+    """dds-proxy STPs without a subscription whose switching service is already subscribed."""
+    subscribed = subscribed_values("ServiceTerminationPoint", "stp_id")
+    switching_services = subscribed_values("SwitchingService", "switching_service_id")
+    return [
+        stp
+        for stp in fetch_service_termination_points()
+        if stp.id not in subscribed and stp.switching_service_id in switching_services
+    ]
+
+
+def stp_selector(stps: list[DdsServiceTerminationPoint]) -> type[Choice]:
+    """Build a dropdown of ``stps``, keyed by ``stp_id`` and labelled ``name (id)``."""
+    options = {stp.id: f"{stp.name} ({stp.id})" for stp in stps}
+    choices = Choice("ServiceTerminationPoint", zip(options.keys(), options.items()))  # type: ignore[arg-type]
+    return cast("type[Choice]", choices)
+
+
+def switchingservice_block_for(switching_service_id: str) -> SwitchingServiceBlock:
+    """Return the SwitchingServiceBlock of the subscription that owns ``switching_service_id``."""
+    subscription_id = subscription_id_for_value("SwitchingService", "switching_service_id", switching_service_id)
+    # never None: available_service_termination_points only offers stps whose switching service is subscribed
+    assert subscription_id is not None
+    return SwitchingService.from_subscription(subscription_id).switchingservice

--- a/workflows/stp/terminate_stp.py
+++ b/workflows/stp/terminate_stp.py
@@ -1,0 +1,45 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.forms import FormPage
+from orchestrator.core.forms.validators import DisplaySubscription
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.utils import terminate_workflow
+from pydantic_forms.types import InputForm, State, UUIDstr
+
+from products.product_types.stp import ServiceTerminationPoint
+
+logger = structlog.get_logger(__name__)
+
+
+def terminate_initial_input_form_generator(subscription_id: UUIDstr, customer_id: UUIDstr) -> InputForm:
+    temp_subscription_id = subscription_id
+
+    class TerminateServiceTerminationPointForm(FormPage):
+        subscription_id: DisplaySubscription = temp_subscription_id  # type: ignore[assignment]
+
+    return TerminateServiceTerminationPointForm
+
+
+@step("Terminate service termination point subscription")
+def terminate_stp_subscription(subscription: ServiceTerminationPoint) -> State:
+    # DDS is read-only, so there is nothing to deprovision; just drop the subscription.
+    logger.info("Terminating service termination point subscription", stp_id=subscription.stp.stp_id)
+
+    return {}
+
+
+@terminate_workflow(initial_input_form=terminate_initial_input_form_generator)
+def terminate_stp() -> StepList:
+    return begin >> terminate_stp_subscription

--- a/workflows/stp/validate_stp.py
+++ b/workflows/stp/validate_stp.py
@@ -1,0 +1,41 @@
+# Copyright 2026 SURF.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import structlog
+from orchestrator.core.workflow import StepList, begin, step
+from orchestrator.core.workflows.utils import validate_workflow
+from pydantic_forms.types import State
+
+from products.product_types.stp import ServiceTerminationPoint
+from services.dds_proxy import fetch_service_termination_points
+
+logger = structlog.get_logger(__name__)
+
+
+@step("Validate service termination point is still present in the DDS")
+def validate_stp_present_in_dds(subscription: ServiceTerminationPoint) -> State:
+    """Assert the subscription's stp_id is still advertised by the dds-proxy."""
+    stp_id = subscription.stp.stp_id
+    known_ids = {stp.id for stp in fetch_service_termination_points()}
+    if stp_id not in known_ids:
+        raise AssertionError(
+            f"Service termination point {stp_id} is no longer present in the dds-proxy "
+            "/service-termination-points endpoint"
+        )
+
+    return {"subscription": subscription}
+
+
+@validate_workflow()
+def validate_stp() -> StepList:
+    return begin >> validate_stp_present_in_dds


### PR DESCRIPTION
Implements #5 — a **ServiceTerminationPoint** product (mirrors SwitchingService) backed by the
nsi-dds-proxy and linked to a switching service, plus a reconcile workflow.

## What's included
- ServiceTerminationPoint product + block (`stp_id`, modifiable `stp_name`, `capacity`,
  `label_group`, `switching_service` link to the `SwitchingServiceBlock`) and the
  create/modify/validate/terminate workflows, plus the migration registering them with a
  `depends_on` on the SwitchingService block.
- **create** — id/name dropdown of dds-proxy `GET /service-termination-points` entries that have no
  subscription yet and whose switching service is already subscribed; derives `stp_name`,
  `capacity`, `label_group` from the chosen STP and links its switching-service block.
- **modify** — change `stp_name`. **validate** — assert `stp_id` is still advertised. **terminate**
  — drop the subscription.
- **reconcile** — hand-written `@reconcile_workflow` that updates `capacity` from the DDS (leaves it
  untouched if the STP is gone); registered via a `Target.RECONCILE` migration row.
- `DdsServiceTerminationPoint` + `fetch_service_termination_points()` on the dds-proxy client.
- Registered the description, product-block title (strips `urn:ogf:network:`), the product, the
  workflows, and en-GB translations.

## Verification
- `ruff` / `ruff format --check` / `mypy .` (48 files) / `pytest` (20 passed) all green.
- Migration applied to the local nsi DB (`e9c7f020ab00 -> b66721b43c63`); `wsgi` loads with all
  three products and the five STP workflows (reconcile included).
- dds-proxy parsing/selector/availability-filter/description covered by unit tests; the live
  `/service-termination-points` route is exercised via mocks.

Closes #5